### PR TITLE
fix(verifier): acquire HTTP port atomically

### DIFF
--- a/proxy/http_test.go
+++ b/proxy/http_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -72,19 +73,20 @@ func TestChainHandlers(t *testing.T) {
 func TestHTTPReverseProxy(t *testing.T) {
 
 	// Setup target to proxy
-	port, err := HTTPReverseProxy(Options{
+	listener, err := HTTPReverseProxy(Options{
 		Middleware: []Middleware{
 			DummyMiddleware("1"),
 		},
 		TargetScheme:  "http",
 		TargetAddress: "127.0.0.1:1234",
 	})
-
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
 
-	if port == 0 {
-		t.Errorf("want non-zero port, got %v", port)
+	defer listener.Close()
+
+	if tcpAddr, ok := listener.Addr().(*net.TCPAddr); !ok || tcpAddr.Port == 0 {
+		t.Errorf("want non-zero port, got %v", listener.Addr())
 	}
 }


### PR DESCRIPTION
Acquire the port in VerifyMessageProvider and VerifyProvider atomically by using the listener used for a free port acquisition for the HTTP server.

This prevents a race condition when multiple pact verifiers run in parallel and compete for free ports, which could result in errors like

```
Expected server to start < 10s. Timed out waiting for http verification proxy on port 34425 - check for errors
```